### PR TITLE
Fixed markdown error in heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#PDFLayoutTextStripper
+# PDFLayoutTextStripper
 
 -
 Converts a PDF file into a text file while keeping the layout of the original PDF. Useful to extract the content from a table or a form in a PDF file. PDFLayoutTextStripper is a subclass of PDFTextStripper class (from the [Apache PDFBox](https://pdfbox.apache.org/) library).


### PR DESCRIPTION
The h1 heading wasn't appearing because no space after the hash.