### PR TITLE
Handle java.lang.StringIndexOutOfBoundsException:  at TextLine.isSpac…

### DIFF
--- a/PDFLayoutTextStripper.java
+++ b/PDFLayoutTextStripper.java
@@ -264,7 +264,25 @@ class TextLine {
     }
 
     private boolean isSpaceCharacterAtIndex(int index) {
-        return this.line.charAt(index) != SPACE_CHARACTER;
+
+        boolean testSpaceChar=false;
+
+        try {
+
+            this.line.charAt(index);
+            if (this.line.charAt(index) > 0) {
+                System.out.println(this.line.charAt(index));
+                test = this.line.charAt(index) != SPACE_CHARACTER;
+                return testSpaceChar;
+            }
+
+
+        } catch (StringIndexOutOfBoundsException siobe) {
+            System.out.println("invalid input");
+        } finally {
+            return testSpaceChar;
+        }
+
     }
 
     private boolean isNewIndexGreaterThanLastIndex(int index) {


### PR DESCRIPTION
…eCharacterAtIndex when you have to deal with bad documents

Sometimes when text is coming from OCRed PDF documents which are of poor quality I get a StringIndexOutOfBoundsException at PDFLayoutTextStripper.java:275. With this update of method "isSpaceCharacterAtIndex(int index)", characters continue to append and operations completes succesfully.