### PR TITLE
Fix bug in master

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Data extraction from a form in a PDF file
 
 ### Manual
 1) Install **apache pdfbox** manually ([to get the v2.0.6 click here](https://mvnrepository.com/artifact/org.apache.pdfbox/pdfbox/2.0.6) ) and its two dependencies
-commons-logging.jar and fontbox
+commons-logging.jar (https://commons.apache.org/proper/commons-logging/download_logging.cgi) and fontbox (https://mvnrepository.com/artifact/org.apache.pdfbox/fontbox/2.0.0)
 
 >**warning**: only pdfbox versions **from version 2.0.0 upwards** are compatible with this version of PDFLayoutTextStripper.java
 
@@ -30,8 +30,8 @@ commons-logging.jar and fontbox
 ### How to use on Linux/Mac
 ```
 cd PDFLayoutTextStripper
-javac -cp .:/pathto/pdfbox-2.0.6.jar:/pathto/commons-logging-1.2.jar:/pathto/PDFLayoutTextStripper/fontbox-2.0.6.jar *.java
-java -cp .:/pathto/pdfbox-2.0.6.jar:/pathto/commons-logging-1.2.jar:/pathto/PDFLayoutTextStripper/fontbox-2.0.6.jar test
+javac -cp .:/pathto/pdfbox-2.0.6.jar:/pathto/commons-logging-1.2.jar:/pathto/fontbox-2.0.6.jar *.java
+java -cp .:/pathto/pdfbox-2.0.6.jar:/pathto/commons-logging-1.2.jar:/pathto/fontbox-2.0.6.jar test
 ```
 
 ### How to use on Windows

--- a/test.java
+++ b/test.java
@@ -17,7 +17,7 @@ public class test {
             PDFParser pdfParser = new PDFParser(new RandomAccessFile(new File("./samples/bus.pdf"), "r"));
             pdfParser.parse();
             PDDocument pdDocument = new PDDocument(pdfParser.getDocument());
-            PDFTextStripper pdfTextStripper = new PDFLayoutTextStripper();
+            PDFTextStripper pdfTextStripper = new PDFTextStripper();
             string = pdfTextStripper.getText(pdDocument);
         } catch (FileNotFoundException e) {
             e.printStackTrace();


### PR DESCRIPTION
There is a fatal bug in master which references the wrong object and returns this error; 

```
test.java:20: error: cannot find symbol
            PDFTextStripper pdfTextStripper = new PDFLayoutTextStripper();
                                                  ^
  symbol:   class PDFLayoutTextStripper
  location: class test
1 error
```

This fix corrects the referenced object and adds some clarifications to the README.